### PR TITLE
chore: quick wins — OpenAPI, Docker image workflow, Dependabot, Makefile/docker-compose

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,34 @@
+name: Docker image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:v${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# multi-stage build: build jar then create runtime image
+FROM maven:3.9.6-eclipse-temurin-17 as builder
+WORKDIR /workspace
+COPY pom.xml mvnw .
+COPY .mvn .mvn
+COPY src src
+RUN mvn -B -DskipTests package
+
+FROM eclipse-temurin:17-jre-jammy
+ARG JAR_FILE=target/demo-0.0.1-SNAPSHOT.jar
+COPY --from=builder /workspace/${JAR_FILE} /app/app.jar
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+BUILD_JAR=target/demo-0.0.1-SNAPSHOT.jar
+IMAGE_NAME=demo:latest
+
+.PHONY: all build test run docker-build clean
+
+all: build
+
+build:
+	./mvnw -B -DskipTests package
+
+test:
+	./mvnw test
+
+run:
+	./mvnw spring-boot:run
+
+docker-build: build
+	docker build -t $(IMAGE_NAME) .
+
+clean:
+	./mvnw -B clean

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ This project is licensed under the Apache-2.0 License — see the `LICENSE` file
 
 - Please update the `pom.xml` `scm` and `url` values with your GitHub repository URL after creating the remote (e.g., `https://github.com/<your-username>/demo`).
 
+## 📚 API documentation
+
+This project exposes OpenAPI docs via `springdoc-openapi`. When running locally the Swagger UI is available at `/swagger-ui/index.html` (or `/swagger-ui.html` depending on version). Add the dependency `org.springdoc:springdoc-openapi-starter-webflux-ui` to `pom.xml` to enable it.
+
 ## 📤 Publish to GitHub
 
 You can create the remote repository and push the current branch with either:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    image: demo:latest
+    ports:
+      - "8080:8080"
+    environment:
+      - JAVA_OPTS=-Xms256m -Xmx512m

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>


### PR DESCRIPTION
This PR implements quick, small improvements referenced by issues #2, #3, #5, and #8:

- Add OpenAPI docs support via `springdoc-openapi-starter-webflux-ui` (issue #2)
- Add `Dockerfile` and `docker.yml` workflow to build and push image on tag (issue #3)
- Add `.github/dependabot.yml` to enable weekly Maven dependency updates (issue #5)
- Add `Makefile` and `docker-compose.yml` for local development convenience (issue #8)

Notes:
- CI/Secrets: Docker workflow pushes to GHCR; set `permissions.packages` and ensure `GITHUB_TOKEN` has package write access or add a PAT if needed.
- Swagger UI: available at `/swagger-ui/index.html` when running locally.

Please review: @sebastienblanc